### PR TITLE
add documentation and ability to use private constructs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ libs: {
   "@aws-cdk/aws-amplify-alpha": "2.x",
   ...
   "@aws-cdk/region-info": "2.x",
-  "my-cool-lib-1.2.3.tgz": "tar" // <-- This is the line to add, use filename as found in ./src/react-app/src/public/constructs as the key, and "tar" as the value
+  "my-cool-lib-1.2.3.tgz": "local" // <-- This is the line to add, use filename as found in ./src/react-app/src/public/constructs as the key, and "local" as the value
 },
 
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 # Features
 
-AWS CDK Builder is a browser-based tool designed to streamline bootstrapping of Infrastructure as Code (IaC) projects using the AWS Cloud Development Kit (CDK). Equipped with a dynamic visual designer and instant TypeScript code generation capabilities, the CDK Builder simplifies the construction and deployment of CDK projects. It stands as a resource for all CDK users, providing a platform to explore a broad array of CDK constructs. 
+AWS CDK Builder is a browser-based tool designed to streamline bootstrapping of Infrastructure as Code (IaC) projects using the AWS Cloud Development Kit (CDK). Equipped with a dynamic visual designer and instant TypeScript code generation capabilities, the CDK Builder simplifies the construction and deployment of CDK projects. It stands as a resource for all CDK users, providing a platform to explore a broad array of CDK constructs.
 
 ![sample](assets/aws-cdk-builder-code.png "AWS CDK Builder")
 ![sample](assets/aws-cdk-builder-diagram.png "AWS CDK Builder")
@@ -33,7 +33,7 @@ But if you wish to deploy it on your own account, here is a step-by-step guide.
 ### Environment setup
 
 #### Deploy with AWS Cloud9
-We recommend deploying with [AWS Cloud9](https://aws.amazon.com/cloud9/). 
+We recommend deploying with [AWS Cloud9](https://aws.amazon.com/cloud9/).
 If you'd like to use Cloud9 to deploy the solution, you will need the following before proceeding:
 - use `Ubuntu Server 22.04 LTS` as the platform.
 
@@ -112,6 +112,32 @@ npx cdk destroy
 AWS CDK Builder is a serverless static website application, created using React and TypeScript.
 
 ![sample](assets/architecture.png "Architecture Diagram")
+
+# Adding Private Constructs
+If there are constructs which are not in the public npm js registry, they can be added as follows:
+
+1. Download the npm package:
+```bash
+npm pack <your-package> --pack-destination ./public/constructs
+```
+
+2. Modify a blueprint to use the newly added package. For example, to change the `Blank` blueprint:
+```bash
+open ./src/react-app/src/blueprints/cdk-blank.ts
+```
+
+3. Modify `libs: {` as follows:
+```typescript
+libs: {
+  "@aws-cdk/aws-amplify-alpha": "2.x",
+  ...
+  "@aws-cdk/region-info": "2.x",
+  "my-cool-lib-1.2.3.tgz": "tar" // <-- This is the line to add, use filename as found in ./src/react-app/src/public/constructs as the key, and "tar" as the value
+},
+
+```
+
+Now when a project is created using the modified blueprint, it will have access to the private constructs.
 
 # License
 

--- a/src/react-app/src/packages/package-manager.ts
+++ b/src/react-app/src/packages/package-manager.ts
@@ -17,10 +17,20 @@ export class PackageManager {
 
   async getPackage(packageName: string, version: string) {
     const cache = await caches.open("packages");
-    const { metadata, tarball, targetVersion } = await this.getPackageMetadata(
-      packageName,
-      version
-    );
+
+    if (version =="tar"){
+      const targetVersion = packageName.substring(packageName.length-9,packageName.length-4);
+      var packageMetaData = {metadata: {}, tarball: `../constructs/${packageName}`, version: targetVersion}
+    }
+    else{
+      // I'm almost positive there's a better way to handle this than var. I just don't know what it is.
+      var packageMetaData = await this.getPackageMetadata(
+        packageName,
+        version
+      );
+    }
+
+  let {metadata, tarball, targetVersion} = packageMetaData;
 
     let data: Uint8Array | null = null;
     const packageKeyPrefix = this.getPackageKeyPrefix(packageName);

--- a/src/react-app/src/packages/package-manager.ts
+++ b/src/react-app/src/packages/package-manager.ts
@@ -18,11 +18,11 @@ export class PackageManager {
   async getPackage(packageName: string, version: string) {
     const cache = await caches.open("packages");
 
-    if (version =="tar"){
-      const targetVersion = packageName.substring(packageName.length-9,packageName.length-4);
-      var packageMetaData = {metadata: {}, tarball: `../constructs/${packageName}`, version: targetVersion}
+    if (version == "local") {
+      const targetVersion = packageName.substring(packageName.length - 9, packageName.length - 4);
+      var packageMetaData = { metadata: {}, tarball: `../constructs/${packageName}`, version: targetVersion }
     }
-    else{
+    else {
       // I'm almost positive there's a better way to handle this than var. I just don't know what it is.
       var packageMetaData = await this.getPackageMetadata(
         packageName,
@@ -30,7 +30,7 @@ export class PackageManager {
       );
     }
 
-  let {metadata, tarball, targetVersion} = packageMetaData;
+    let { metadata, tarball, targetVersion } = packageMetaData;
 
     let data: Uint8Array | null = null;
     const packageKeyPrefix = this.getPackageKeyPrefix(packageName);


### PR DESCRIPTION
Addresses #4 

*Description of changes:*
Add ability to add constructs from a provided tar file. This opens the possibility of using private construct sources instead of only public npm packages.

Please note the use of var in package-manager and either provide feedback on the best way to do that, or let me know if that's OK and I'll remove the comment in there. I am not a very seasoned TS dev and I don't want hacks like that to make it into tools if they don't have to be there.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
